### PR TITLE
🐛 Fix a `SystemError: seek: Bad file descriptor`

### DIFF
--- a/src/request.jl
+++ b/src/request.jl
@@ -90,6 +90,7 @@ function deserialize_zipfile(data_location::String, name::String; fold::Int64 = 
 
     end
 
+    close(reader)
 
     return RelationalDataset((
         train_pos,


### PR DESCRIPTION
This seemed to show up randomly when running the load-webkb
fold-2 test, but was inconsistent.

It looks like calling `close(reader)` explicitly removes this.