### PR TITLE
🚑️ Fix column-vector design of `X` in convert

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -34,7 +34,7 @@ function from_vector(X::Matrix{Int64}, y::Vector{Int64}, names::Union{Vector{Str
         end
     end
 
-    for (i, col) in enumerate(eachrow(X))
+    for (i, col) in enumerate(eachcol(X))
         var = names[i]
         facts = vcat(facts, ["$(var)(id$(j),$(row))." for (j, row) in enumerate(col)])
     end
@@ -68,7 +68,7 @@ function from_vector(X::Matrix{Int64}, y::Vector{Float64}, names::Union{Vector{S
         push!(pos, "regressionExample($(last(names))(id$(i)),$(row)).")
     end
 
-    for (i, col) in enumerate(eachrow(X))
+    for (i, col) in enumerate(eachcol(X))
         var = names[i]
         facts = vcat(facts, ["$(var)(id$(j),$(row))." for (j, row) in enumerate(col)])
     end

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -9,7 +9,7 @@ using RelationalDatasets
 @testset "Test converting propositional datasets" begin
 
     @test RelationalDatasets.from_vector(
-        [[0, 1, 1] [1, 0, 2] [2, 2, 0]],
+        [0 1 1; 1 0 2; 2 2 0],
         [0, 0, 1],
     ) == (RelationalDatasets.RelationalDataset((
             pos=["v4(id3)."],
@@ -34,7 +34,7 @@ using RelationalDatasets
     )
 
     @test RelationalDatasets.from_vector(
-        [[0, 1, 1] [1, 0, 2] [2, 2, 0]],
+        [0 1 1; 1 0 2; 2 2 0],
         [0.1, 0.2, 0.3],
     ) == (RelationalDatasets.RelationalDataset((
         pos=[
@@ -63,7 +63,7 @@ using RelationalDatasets
     )
 
     @test RelationalDatasets.from_vector(
-        [[1, 1] [0, 1]],
+        [1 1; 0 1],
         [0, 1],
         ["a", "b", "c"],
     ) == (RelationalDatasets.RelationalDataset((
@@ -83,7 +83,7 @@ using RelationalDatasets
     )
 
     @test RelationalDatasets.from_vector(
-        [[1, 1] [0, 1]],
+        [1 1; 0 1],
         [0.5, 1.0],
         ["a", "b", "c"],
     ) == (RelationalDatasets.RelationalDataset((
@@ -104,19 +104,19 @@ using RelationalDatasets
 end
 
 @testset "Misaligned Classification and Regression" begin
-    @test_throws AssertionError RelationalDatasets.from_vector([[1] [2]], [1])
-    @test_throws AssertionError RelationalDatasets.from_vector([[1] [2]], [0.5])
+    @test_throws AssertionError RelationalDatasets.from_vector([1 2], [1])
+    @test_throws AssertionError RelationalDatasets.from_vector([1 2], [0.5])
 end
 
 @testset "Misaligned Custom Variable Names" begin
     @test_throws AssertionError RelationalDatasets.from_vector(
-        [[1] [2]],
+        [1 2],
         [1],
         ["a", "b", "c", "d"],
     )
 
     @test_throws AssertionError RelationalDatasets.from_vector(
-        [[1] [2]],
+        [1 2],
         [0.5],
         ["a", "b", "c", "d"]
     )


### PR DESCRIPTION
I made a mistake when implementing the specification: I implemented the matrices with a row-vector representation instead of the needed column-vector representation.

This fixes the implementation and the tests.